### PR TITLE
Missing content-type header from curl

### DIFF
--- a/docs/flashbots-core/miners/mev-geth-spec/v01-rpc.md
+++ b/docs/flashbots-core/miners/mev-geth-spec/v01-rpc.md
@@ -23,7 +23,7 @@ maxTimestamp	|`Quantity`	|Maximum (inclusive) block timestamp at which the bundl
 
 ```bash
 # Request
-curl -X POST --data '{
+curl -X POST -H 'Content-Type: application/json' --data '{
     "id": 1337,
     "jsonrpc": "2.0",
     "method": "eth_sendBundle",
@@ -68,7 +68,7 @@ Map<`Data`, "error|value" : `Data`> - a mapping from transaction hashes to execu
 
 ```bash
 # Request
-curl -X POST --data '{
+curl -X POST -H 'Content-Type: application/json' --data '{
     "id": 1337,
     "jsonrpc": "2.0",
     "method": "eth_callBundle",

--- a/docs/flashbots-core/miners/mev-geth-spec/v02-rpc.md
+++ b/docs/flashbots-core/miners/mev-geth-spec/v02-rpc.md
@@ -24,7 +24,7 @@ revertingTxHashes	|Array<`Data`>	|Array of tx hashes within the bundle that are 
 
 ```bash
 # Request
-curl -X POST --data '{
+curl -X POST -H 'Content-Type: application/json' --data '{
     "id": 1337,
     "jsonrpc": "2.0",
     "method": "eth_sendBundle",
@@ -71,16 +71,18 @@ Map<`Data`, "error|value" : `Data`> - a mapping from transaction hashes to execu
 
 ```bash
 # Request
-curl -X POST --data '{
+curl -X POST -H 'Content-Type: application/json' --data '{
     "id": 1337,
     "jsonrpc": "2.0",
     "method": "eth_callBundle",
     "params": [
-        [
-            "f9014946843b9aca00830493e094a011e5f4ea471ee4341a135bb1a4af368155d7a280b8e40d5f2659000000000000000000000000fdd45a22dd1d606b3782f2119621e928e32743000000000000000000000000000000000000000000000000000000000077359400000000000000000000000000000000000000000000000",
-            "f86e8204d085012a05f200830c350094daf24c20717f428f00d8448d74d67a77f67ceb8287354a6ba7a18000802ea00e411bcb660dd8d47717df89078d2e8160c08e7f11cb7ad0ee935e7436eceb32a013ee00a21b7fa0a9f9c1224d11261648191875d4633aed6003543ea319f12b62"
-        ],
-        "0x12ab34"
+        {
+            "txs": [
+                "f9014946843b9aca00830493e094a011e5f4ea471ee4341a135bb1a4af368155d7a280b8e40d5f2659000000000000000000000000fdd45a22dd1d606b3782f2119621e928e32743000000000000000000000000000000000000000000000000000000000077359400000000000000000000000000000000000000000000000",
+                "f86e8204d085012a05f200830c350094daf24c20717f428f00d8448d74d67a77f67ceb8287354a6ba7a18000802ea00e411bcb660dd8d47717df89078d2e8160c08e7f11cb7ad0ee935e7436eceb32a013ee00a21b7fa0a9f9c1224d11261648191875d4633aed6003543ea319f12b62"
+            ],
+            "blockNumber": "0x12ab34"
+        }
     ]
 }' <url>
 

--- a/docs/flashbots-core/searchers/advanced/rpc-endpoint.md
+++ b/docs/flashbots-core/searchers/advanced/rpc-endpoint.md
@@ -30,7 +30,7 @@ The `eth_sendBundle` RPC has the following payload format:
 To authenticate your request, the relay requires you sign the payload and include the signed payload in the `X-Flashbots-Signature` header of your request.
 
 ```curl
-curl -X POST -H "X-Flashbots-Signature: 0x1234:0xabcd" --data '{"jsonrpc":"2.0","method":"eth_sendBundle","params":[{see above}],"id":1}' https://relay.flashbots.net
+curl -X POST -H "Content-Type: application/json" -H "X-Flashbots-Signature: 0x1234:0xabcd" --data '{"jsonrpc":"2.0","method":"eth_sendBundle","params":[{see above}],"id":1}' https://relay.flashbots.net
 ```
 
 Any valid Ethereum key can be used to sign the payload. The Ethereum address associated with this key will be used by the relay to keep track of your requests over time and provide user statistics. You can change the key you use at any time.


### PR DESCRIPTION
Change callBundle to the new 0.2 format (although the old still works for now)