### PR TITLE
Add missing coma to authSigner

### DIFF
--- a/docs/flashbots-auction/searchers/advanced/goerli-testnet.mdx
+++ b/docs/flashbots-auction/searchers/advanced/goerli-testnet.mdx
@@ -8,7 +8,7 @@ Flashbots operates a Goerli validator and searchers can test Flashbots by using 
 const provider = new ethers.getDefaultProvider("goerli");
 
 const authSigner = new ethers.Wallet(
-  '0x2000000000000000000000000000000000000000000000000000000000000000'
+  '0x2000000000000000000000000000000000000000000000000000000000000000',
   provider
 );
   


### PR DESCRIPTION
Without the comma, it is only passing one arg