### PR TITLE
fix(docs): links and formatting

### DIFF
--- a/docs/flashbots-auction/other-resources.md
+++ b/docs/flashbots-auction/other-resources.md
@@ -4,9 +4,8 @@ title: other resources
 
 Remember you can ask any questions in the [#🤖searchers](https://discord.gg/d9XYzHA4hM) channel on our Discord, below are a list of useful resources for searchers to wrap their heads around running Flashbots:
 
-
-* A technical overview of Flashbots the organization: https://ethresear.ch/t/flashbots-frontrunning-the-mev-crisis/8251
-* Our values and what we stand for: https://medium.com/flashbots/frontrunning-the-mev-crisis-40629a613752
+* A technical overview of Flashbots the organization: <https://ethresear.ch/t/flashbots-frontrunning-the-mev-crisis/8251>
+* Our values and what we stand for: <https://medium.com/flashbots/frontrunning-the-mev-crisis-40629a613752>
 * [Flashbots: MEV Of The Week thread](https://twitter.com/epheph/status/1357089176898969600?s=20) by Scott Bigelow
 * [Lost ENS sanctuary using Flashbots](https://twitter.com/andrekorol1/status/1358252320207876104?s=19) by Andre Korol 🔥
 * [The enemy of your enemy is NOT your friend](https://fiona.mirror.xyz/QXdCOAggA5g_j5R_JpO-V5LqK89EbimnYIV6c2rOsT0) by Fiona Kobayashi

--- a/docs/flashbots-auction/searchers/advanced/reputation.md
+++ b/docs/flashbots-auction/searchers/advanced/reputation.md
@@ -25,7 +25,7 @@ $\Delta_{coinbase_T}$: coinbase difference from direct payment in transaction $T
 
 Flashbots uses a dynamic threshold to classify users between the high reputation and low reputation queue. The dynamic variables are: 1) the historical time period considered to calculate reputation, 2) the cutoff reputation score which classifies a searcher as "high reputation". Using a dynamic threshold allows the relay to adapt in periods of high demand and maintain high reliability for top searchers.
 
-A searcher can query their current reputation status using the [`flashbots_getUserStats` RPC method](https://github.com/flashbots/mev-relay-js#flashbots_getuserstats).
+A searcher can query their current reputation status using the [`flashbots_getUserStats` RPC method](https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#flashbots_getuserstats).
 
 ## Building reputation
 

--- a/docs/flashbots-auction/searchers/faq.md
+++ b/docs/flashbots-auction/searchers/faq.md
@@ -108,7 +108,7 @@ Rate limiting is currently in place to protect the relay infrastructure from DOS
 
 By signing payloads with your own relay signing key, this will enable building a reputation for high-priority delivery of your bundles to miners. The Flashbots Relay simulates bundles before sending to miners which can take a small amount of time. The relay cannot determine which bundles are profitable without performing a full simulation. This signing key allows the relay to infer which bundles are likely profitable, based on historical performance. Using a reputation system allows reliable searchers to be rewarded for good performance while still allowing new searchers to participate.
 
-You can query the relay to obtain an understanding of your [reputation score](https://github.com/flashbots/mev-relay-js#flashbots_getuserstats).
+You can query the relay to obtain an understanding of your [reputation score](https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#flashbots_getuserstats).
 
 ### Are you on any testnets?
 

--- a/docs/flashbots-auction/upgrade-process.md
+++ b/docs/flashbots-auction/upgrade-process.md
@@ -16,9 +16,11 @@ We do not make any commitments around how frequently / quickly these upgrades wi
 ![Flashbots Auction Upgrades](/img/gant-chart-upgrade.png)
 
 ## Feature selection process
+
 The goal of the feature selection process is to surface feature requests from the community and collaborate on implementation.
 
 Product Manager (PM): @thegostep
+
 1. Feature requests are submitted by anyone to the [flashbots forum](https://github.com/flashbots/pm/discussions) and titled 'Feature request:'
 2. The PM is responsible for engaging and moderating the forums
 3. The PM updates the ['core releases' project board](https://github.com/orgs/flashbots/projects/6) to keep track of feature requests and assigns them to target releases
@@ -27,11 +29,13 @@ Product Manager (PM): @thegostep
 6. Feedback is incorporated into the formal specification
 
 ## Formal specification and reference implementation
+
 We've learned that despite maintaining a reference implementation of mev-geth, miners tend to re-implement our feature set on their own custom nodes. This has lead to some confusion around what are "required" vs "nice to have" features as well as bugs which have lead to unexpected behaviors like mining unprofitable / reverting bundles.
 
 By producing a formal specification and updating it on each release, we aim to provide a document that clearly outlines the expected behavior of the node implementation and use it to grant / withhold access to the relay.
 
 ## Versioned deployment and testing
+
 To provide the best possible availability and correctness guarantees to the Flashbots Network, we aim to perform upgrades in a way that minimizes disruptions. This involves a 'rolling' upgrade process where searchers can define which version of Flashbots Auction they are targeting.
 
 At a selected block height, the relay will route all searcher bundles exclusively to the nodes that have implemented the new specification. A searcher desiring to remain on a previous version may do so by [specifying the target version](https://github.com/flashbots/mev-relay-js/issues/37) until a predetermined deprecation block height where the old version will no longer be supported by the relay.
@@ -41,13 +45,13 @@ Miners will want to begin implementing the changes required as soon as the updat
 These tests involve receiving and mining a series of bundles on a test environment which can be analyzed by the flashbots team. The tests will cover a range of known edge cases including but not limited to:
 
 - logic testing
-    - block formation / ordering
-    - bundle prioritization
-    - bundle atomicity
+  - block formation / ordering
+  - bundle prioritization
+  - bundle atomicity
 - probabilistic testing
-    - custom profit switcher
-    - latency and delays
-    - mempool volume
+  - custom profit switcher
+  - latency and delays
+  - mempool volume
 
 ## Monitoring continuing performance
 

--- a/docs/flashbots-data/blockapi.md
+++ b/docs/flashbots-data/blockapi.md
@@ -3,4 +3,4 @@ title: mev-blocks API
 ---
 mev-blocks is a a public API for displaying flashbots blocks and transactions.
 
-Access it here: https://blocks.flashbots.net/
+Access it here: <https://blocks.flashbots.net/>

--- a/docs/flashbots-data/dashboard.md
+++ b/docs/flashbots-data/dashboard.md
@@ -3,7 +3,8 @@ title: flashbots dashboard
 ---
 Flashbots Dashboard v0 is a near real-time analytics dashboard of Flashbots activity on Ethereum.
 
-You can access the dashboard here: https://dashboard.flashbots.net and more information about the data & metrics it uses here: https://dashboard.flashbots.net/data-metrics.
+You can access the dashboard here: <https://dashboard.flashbots.net> and more information about the data & metrics it uses here: <https://dashboard.flashbots.net/data-metrics>.
 
 Extra resources:
+
 * [Tweetstorm](https://twitter.com/bertcmiller/status/1392871268953858057) introducing the dashboard

--- a/docs/flashbots-data/mev-explore.md
+++ b/docs/flashbots-data/mev-explore.md
@@ -3,7 +3,8 @@ title: mev-explore
 ---
 MEV-Explore v0 is a live dashboard of MEV activity on the Ethereum network and MEV transactions explorer.
 
-You can access the dashboard here: https://explore.flashbots.net and documentation about the metrics we are displaying here: https://explore.flashbots.net/data-metrics.
+You can access the dashboard here: <https://explore.flashbots.net> and documentation about the metrics we are displaying here: <https://explore.flashbots.net/data-metrics>.
 
 Extra resources:
-*  Explore v0 launch blogpost: [Quantifying MEV: Introducing MEV-Explore v0](https://medium.com/flashbots/quantifying-mev-introducing-mev-explore-v0-5ccbee0f6d02)
+
+* Explore v0 launch blogpost: [Quantifying MEV: Introducing MEV-Explore v0](https://medium.com/flashbots/quantifying-mev-introducing-mev-explore-v0-5ccbee0f6d02)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.0.0-alpha.72",
-    "@tsconfig/docusaurus": "^1.0.2",
+    "@tsconfig/docusaurus": "^1.0.4",
     "@types/react": "^17.0.3",
     "@types/react-helmet": "^6.1.0",
     "@types/react-router-dom": "^5.1.7",

--- a/static/img/site.webmanifest
+++ b/static/img/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"flashbots documentation","short_name":"flashbots-docs","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,10 +1734,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tsconfig/docusaurus@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-1.0.2.tgz#400ef146d3e7da2f78bf9749c943d123dce5fd97"
-  integrity sha512-x4rRVb346vjyym6QbeB1Tv01XXwhbkujOmvDmtf0bT20oc2gbDhbmwpskKqZ5Of2Q/Vk4jNk1WMiLsZdJ9t7Dw==
+"@tsconfig/docusaurus@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-1.0.4.tgz#fc40f87a672568678d83533dd4031a09d75877ca"
+  integrity sha512-I6sziQAzLrrqj9r6S26c7aOAjfGVXIE7gWdNONPwnpDcHiMRMQut1s1YCi/APem3dOy23tAb2rvHfNtGCaWuUQ==
 
 "@types/github-slugger@^1.3.0":
   version "1.3.0"


### PR DESCRIPTION
fixes broken link for reputation scoring, it use to point to mev-relay-js which just points to mev-relay-js providing a 400 error (not implemented) 


```
You can query the relay to obtain an understanding of your [reputation score](https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#flashbots_getuserstats).
```