### PR TITLE
Fixed a typo for missing 't' in the word cannot

### DIFF
--- a/docs/flashbots-auction/overview.mdx
+++ b/docs/flashbots-auction/overview.mdx
@@ -47,7 +47,7 @@ Ultimately, the design goals are the following:
 - **Efficiency**: implies MEV extraction is performed without causing unnecessary network or chain congestion.
 - **Bundle merging**: implies it is possible to merge multiple incoming bundles without conflict.
 - **Finality protection**: implies it is impractical for Flashbots blocks containing Flashbots bundles to be modified once propagated to the network. This would protect against time-bandit chain re-org attacks.
-- **Complete privacy**: implies intermediaries like relayers and miners canno observe the content of transactions until mined on chain.
+- **Complete privacy**: implies intermediaries like relayers and miners cannot observe the content of transactions until mined on chain.
 - **Permissionless**: implies there are no trusted intermediaries which can censor transactions.
 
 | Stage                | PGA | DarkPool | ⚡🤖 v0.1 | ⚡🤖 v0.2 | ⚡🤖 v0.x | ⚡🤖 v1.0 |


### PR DESCRIPTION
There was a `t` missing in the word `cannot`.

```diff
- ... implies intermediaries like relayers and miners canno observe ...
+ ... implies intermediaries like relayers and miners cannot observe ...
```