### PR TITLE
fix: Update broken link

### DIFF
--- a/docs/joining-flashbots.mdx
+++ b/docs/joining-flashbots.mdx
@@ -6,6 +6,6 @@ title: join flashbots
 We are not your typical project, we are fully remote and our principles are based on that of a [pirate hacker collective](https://www.youtube.com/watch?v=T0fAznO1wA8). If you are a self-directed individual who puts collective success above your own and are motivated by solving hard problems with asymmetric impact, you will fit right in.
 
 * [open job positions](https://www.notion.so/flashbots/Flashbots-Job-Board-94d53cb01ef04a9484711dacf18739e3) - full-time roles we're actively recruiting for.
-* [flashbots research fellowship](https://github.com/flashbots/mev-research/blob/main/research_fellowship.md) - we issue research grants to flashbots research proposals submitters. Find out more in our research repo.
+* [flashbots research fellowship](https://github.com/flashbots/mev-research/blob/main/grants.md) - we issue research grants to flashbots research proposals submitters. Find out more in our research repo.
 * flashbots part-time contractor - become a part-time contractor in Flashbots and join one of our ongoing projects. Reach out to the team to learn more!
 * nothing fits in the above? reach out at jobs@flashbots.net


### PR DESCRIPTION
The link to the research fellowship documentation was pointing to a file that was renamed or deleted.
