### PR TITLE
Update mev-inspect-py docs to use the mev commands

### DIFF
--- a/docs/flashbots-data/mev-inspect-py/exploring.md
+++ b/docs/flashbots-data/mev-inspect-py/exploring.md
@@ -6,7 +6,7 @@ All inspect output data is stored in Postgres.
 
 To connect to the local Postgres database for querying, launch a client container with:
 ```
-kubectl run -i --rm --tty postgres-client --env="PGPASSWORD=password" --image=jbergknoff/postgresql-client -- mev_inspect --host=postgresql --user=postgres
+./mev db
 ```
 
 When you see the prompt

--- a/docs/flashbots-data/mev-inspect-py/inspecting.md
+++ b/docs/flashbots-data/mev-inspect-py/inspecting.md
@@ -8,36 +8,62 @@ running inspect for a block will:
 - pull out structured objects like transfers and swaps
 - and save them all to the database for querying
 
-### Inspecting a single block
+### Inspect a single block
 
-Inspecting block [12914944](https://twitter.com/mevalphaleak/status/1420416437575901185)
-```
-kubectl exec deploy/mev-inspect-deployment -- poetry run inspect-block 12914944
-```
+Inspecting block [12914944](https://twitter.com/mevalphaleak/status/1420416437575901185):
 
-### Inspecting many blocks
-
-Inspecting blocks 12914944 to 12914954
 ```
-kubectl exec deploy/mev-inspect-deployment -- poetry run inspect-many-blocks 12914944 12914954
+./mev inspect 12914944
 ```
 
-### Inspecting all incoming blocks
+### Inspect many blocks
 
-Start a block listener with
+Inspecting blocks 12914944 to 12914954:
+
 ```
-kubectl exec deploy/mev-inspect-deployment -- /app/listener start
+./mev inspect-many 12914944 12914954
+```
+
+### Inspect all incoming blocks
+
+Start a block listener with:
+
+```
+./mev listener start
 ```
 
 By default, it will pick up wherever you left off.
-If running for the first time, listener starts at the latest block
+If running for the first time, listener starts at the latest block.
 
-See logs for the listener with
+Tail logs for the listener with:
+
 ```
-kubectl exec deploy/mev-inspect-deployment -- tail -f listener.log
+./mev listener tail
 ```
 
-And stop the listener with
+And stop the listener with:
+
 ```
-kubectl exec deploy/mev-inspect-deployment -- /app/listener stop
+./mev listener stop
 ```
+
+### Backfilling
+
+For larger backfills, you can inspect many blocks in parallel using kubernetes
+
+To inspect blocks 12914944 to 12915044 divided across 10 worker pods:
+```
+./mev backfill 12914944 12915044 10
+```
+
+You can see worker pods spin up then complete by watching the status of all pods
+```
+watch kubectl get pods
+```
+
+To watch the logs for a given pod, take its pod name using the above, then run:
+```
+kubectl logs -f pod/mev-inspect-backfill-abcdefg
+```
+
+(where `mev-inspect-backfill-abcdefg` is your actual pod name)

--- a/docs/flashbots-data/mev-inspect-py/install.md
+++ b/docs/flashbots-data/mev-inspect-py/install.md
@@ -38,7 +38,7 @@ Press "space" to see a browser of the services starting up
 
 On first startup, you'll need to apply database migrations. Apply with:
 ```
-kubectl exec deploy/mev-inspect-deployment -- alembic upgrade head
+./mev exec alembic upgrade head
 ```
 
 ### Tear down

--- a/docs/flashbots-data/mev-inspect-py/quick-start.md
+++ b/docs/flashbots-data/mev-inspect-py/quick-start.md
@@ -14,16 +14,16 @@ Using the [linked etherscan transaction](https://etherscan.io/tx/0xfcf4558f64326
 
 To inspect this block, run
 ```
-kubectl exec deploy/mev-inspect-deployment -- poetry run inspect-block 12914944
+./mev inspect 12914944
 ```
 
 ### Connect to Postgres
 
 We'll connect to the Postgres database to see the data inspect found in that block
 
-Let's start up a client container:
+Let's start up a client container connected to the DB:
 ```
-kubectl run -i --rm --tty postgres-client --env="PGPASSWORD=password" --image=jbergknoff/postgresql-client -- mev_inspect --host=postgresql --user=postgres
+./mev db
 ```
 
 When you see the prompt


### PR DESCRIPTION
Currently the docs are out of sync with the README which uses these fancy simple commands

This brings them back in line

Also adds a description for backfilling