### PR TITLE
Fixed bugs in goerli example

### DIFF
--- a/docs/flashbots-auction/searchers/advanced/goerli-testnet.mdx
+++ b/docs/flashbots-auction/searchers/advanced/goerli-testnet.mdx
@@ -23,13 +23,25 @@ const flashbotsProvider = await flashbots.FlashbotsBundleProvider.create(
 Sending bundles works the same as sending bundles on the mainnet. For example this will simulate a bundle and if it is successful then send a batch of 10:
 
 ```js
+const wallet = new ethers.Wallet(SOME_PRIVATE_KEY);
 const signedTransactions = await flashbotsProvider.signBundle([
     {
-      signer: authSigner,
+      signer: wallet,
       transaction: {
         to: "0xf1a54b075fb71768ac31b33fd7c61ad8f9f7dd18",
         gasPrice: 10,
-        gasLimit: 33000,
+        gasLimit: 21000,
+        chainId: 5,
+        value: 0,
+      },
+    },
+    // we need this second tx because flashbots only accept bundles that use at least 42000 gas.
+    {
+      signer: wallet,
+      transaction: {
+        to: "0xf1a54b075fb71768ac31b33fd7c61ad8f9f7dd18",
+        gasPrice: 10,
+        gasLimit: 21000,
         chainId: 5,
         value: 0,
       },


### PR DESCRIPTION
- The tx signer shouldn't be the flashbot auth signer, so we create a new wallet to sign the txs.
- When running this example, I received a "bundle used too little gas, must use at least 42000" error, so included a 2nd tx to fix this.