### PR TITLE
Add OpenChainBench to community tools

### DIFF
--- a/docs/community-tools.mdx
+++ b/docs/community-tools.mdx
@@ -25,3 +25,7 @@ title: Community Tools
 ### [MEV-Boost Relay & Builder Stats](https://www.relayscan.io/)
 
 - Ethereum MEV-Boost Relay Monitoring.
+
+### [OpenChainBench](https://openchainbench.com)
+
+- Continuous independent benchmarks for MEV-protection RPC endpoints (Flashbots Protect, MEV Blocker, Merkle): latency, success rate, and stale-state detection from 3 global probe regions. Open-source, MIT licensed.


### PR DESCRIPTION
Adds OpenChainBench to the community tools page. OCB continuously benchmarks MEV-protection RPC endpoints including Flashbots Protect — measuring latency, inclusion rate, and stale-state probability from US, EU, and Asia probe regions. Complementary to existing MEV analytics dashboards. Open-source MIT harnesses, CC-BY-4.0 data.